### PR TITLE
chore(release): v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.0](https://github.com/Grazulex/laravel-autobuilder/releases/tag/v1.0.0) (2026-01-04)
+
+### Features
+
+- add rate limiting, health endpoints, authorization, and testing infrastructure ([4b75439](https://github.com/Grazulex/laravel-autobuilder/commit/4b7543990691f05a5ac90d1d8d97f6d0964d8cad))
+- initial release of Laravel AutoBuilder ([934df38](https://github.com/Grazulex/laravel-autobuilder/commit/934df38c69e35f4ccdb3925d8e1c895016493764))
+
+### Bug Fixes
+
+- **ci:** fix GitHub Actions workflows ([e1fd9ff](https://github.com/Grazulex/laravel-autobuilder/commit/e1fd9ff0ac0198d7fefc063ae3916bc80b1c948e))
+
+### Documentation
+
+- add call for testers and community feedback ([e78ec3b](https://github.com/Grazulex/laravel-autobuilder/commit/e78ec3bcfc644880a06a2b501096234112b7ab6d))
+
+### Chores
+
+- fix code style and drop Laravel 10 support ([35b442e](https://github.com/Grazulex/laravel-autobuilder/commit/35b442ec81617632fd9402bcace28da6b9f30987))
+- add GitHub workflows, funding, and standardize project files ([b632d8d](https://github.com/Grazulex/laravel-autobuilder/commit/b632d8d6f2ce3fd1aa1dd310b3a3df2de68ab3f1))
 ## [0.1.0](https://github.com/Grazulex/laravel-autobuilder/releases/tag/v0.1.0) (2025-12-30)
 
 ### Initial Release

--- a/package.json
+++ b/package.json
@@ -1,26 +1,26 @@
 {
-    "name": "laravel-autobuilder",
-    "version": "0.1.0",
-    "private": true,
-    "type": "module",
-    "scripts": {
-        "dev": "vite",
-        "build": "vite build",
-        "preview": "vite preview"
-    },
-    "dependencies": {
-        "@vue-flow/background": "^1.3.2",
-        "@vue-flow/controls": "^1.1.2",
-        "@vue-flow/core": "^1.41.3",
-        "@vue-flow/minimap": "^1.5.2",
-        "lucide-vue-next": "^0.562.0",
-        "vue": "^3.5.13"
-    },
-    "devDependencies": {
-        "@vitejs/plugin-vue": "^5.2.1",
-        "autoprefixer": "^10.4.20",
-        "postcss": "^8.4.49",
-        "tailwindcss": "^3.4.17",
-        "vite": "^6.0.6"
-    }
+  "name": "laravel-autobuilder",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@vue-flow/background": "^1.3.2",
+    "@vue-flow/controls": "^1.1.2",
+    "@vue-flow/core": "^1.41.3",
+    "@vue-flow/minimap": "^1.5.2",
+    "lucide-vue-next": "^0.562.0",
+    "vue": "^3.5.13"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.2.1",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.17",
+    "vite": "^6.0.6"
+  }
 }


### PR DESCRIPTION
## Release v1.0.0

First stable release of Laravel AutoBuilder.

### Features
- Rate limiting for webhook endpoints
- Health check endpoints (`/health`, `/health/detailed`, `/health/stats`)
- FlowPolicy for authorization with super admin support
- Form Request classes for input validation
- Model Factories for testing
- Database indexes for performance
- Comprehensive test suite (823 tests)

### Breaking Changes
- Dropped Laravel 10 support (now requires Laravel 11+)

### Bug Fixes
- Fixed mass assignment vulnerability in CreateModel/UpdateModel

---

After merge, the `v1.0.0` tag will be pushed to create the GitHub release.