### PR TITLE
docs: add matt7ds to contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,3 +253,11 @@ Creator of 17+ Laravel packages with 6,000+ downloads, including:
 - Architecture consulting
 
 Contact: [GitHub](https://github.com/Grazulex)
+
+---
+
+## Contributors
+
+Thanks to these wonderful people for their contributions:
+
+- [@matt7ds](https://github.com/matt7ds) - Bug reports and testing


### PR DESCRIPTION
## Summary
- Add matt7ds to the contributors section in README
- Thanks for reporting issue #10 (webhook_path not being set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)