### PR TITLE
feat: add ability to rename nodes in the flow editor

### DIFF
--- a/resources/js/components/FlowEditor.vue
+++ b/resources/js/components/FlowEditor.vue
@@ -136,6 +136,14 @@ function updateNodeConfig(nodeId, config) {
     }
 }
 
+// Rename a node
+function renameNode(nodeId, newLabel) {
+    const node = nodes.value.find(n => n.id === nodeId)
+    if (node) {
+        node.data = { ...node.data, label: newLabel }
+    }
+}
+
 // Delete selected node - show confirmation first
 function requestDeleteNode() {
     if (!selectedNode.value) return
@@ -540,6 +548,7 @@ onMounted(() => {
             <PropertiesPanel
                 :node="selectedNode"
                 @update="updateNodeConfig"
+                @rename="renameNode"
                 @delete="requestDeleteNode"
             />
         </div>

--- a/resources/js/components/PropertiesPanel.vue
+++ b/resources/js/components/PropertiesPanel.vue
@@ -6,9 +6,24 @@ const props = defineProps({
     node: { type: Object, default: null },
 })
 
-const emit = defineEmits(['update', 'delete'])
+const emit = defineEmits(['update', 'delete', 'rename'])
 
 const localConfig = ref({})
+const isEditingLabel = ref(false)
+const editLabel = ref('')
+
+function startEditLabel() {
+    editLabel.value = props.node.data.label
+    isEditingLabel.value = true
+}
+
+function saveLabel() {
+    const newLabel = editLabel.value.trim()
+    if (newLabel && newLabel !== props.node.data.label) {
+        emit('rename', props.node.id, newLabel)
+    }
+    isEditingLabel.value = false
+}
 
 // Initialize key-value pairs as reactive arrays for the UI
 function getKeyValuePairs(fieldName) {
@@ -123,12 +138,26 @@ const nodeTypeColors = {
         <template v-if="node">
             <!-- Header -->
             <div class="px-4 py-3 border-b flex items-center justify-between">
-                <div class="flex items-center gap-2">
+                <div class="flex items-center gap-2 flex-1 min-w-0">
                     <div
-                        class="w-2 h-2 rounded-full"
+                        class="w-2 h-2 rounded-full shrink-0"
                         :class="nodeTypeColors[node.type]"
                     ></div>
-                    <span class="font-medium text-gray-900">{{ node.data.label }}</span>
+                    <input
+                        v-if="isEditingLabel"
+                        v-model="editLabel"
+                        class="font-medium text-gray-900 text-sm border border-blue-300 rounded px-1.5 py-0.5 w-full focus:outline-none focus:ring-1 focus:ring-blue-500"
+                        @blur="saveLabel"
+                        @keyup.enter="saveLabel"
+                        @keyup.escape="isEditingLabel = false"
+                        @vue:mounted="({ el }) => el.focus()"
+                    >
+                    <span
+                        v-else
+                        class="font-medium text-gray-900 truncate cursor-pointer hover:text-blue-600"
+                        title="Click to rename"
+                        @click="startEditLabel"
+                    >{{ node.data.label }}</span>
                 </div>
                 <button
                     @click="$emit('delete')"


### PR DESCRIPTION
## Summary

- Adds the ability to rename any node (trigger, condition, action) by clicking on its label in the properties panel
- Supports keyboard shortcuts: Enter to save, Escape to cancel
- Auto-focuses the input when editing starts

Closes #21

## Changes

| File | Change |
|------|--------|
| `resources/js/components/PropertiesPanel.vue` | Editable label with click-to-edit, `rename` event |
| `resources/js/components/FlowEditor.vue` | `renameNode` handler + wired `@rename` event |

## Test plan

- [x] 840 existing tests pass
- [ ] Click on node label in properties panel — should become editable
- [ ] Type new name, press Enter — label updates on the node in the canvas
- [ ] Press Escape — edit cancelled, label unchanged
- [ ] Save flow — custom label persists after reload