### PR TITLE
feat(tags): add flow tagging system

### DIFF
--- a/database/factories/TagFactory.php
+++ b/database/factories/TagFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Grazulex\AutoBuilder\Database\Factories;
+
+use Grazulex\AutoBuilder\Models\Tag;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Tag>
+ */
+class TagFactory extends Factory
+{
+    protected $model = Tag::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->word();
+
+        return [
+            'name' => $name,
+            'slug' => Str::slug($name),
+        ];
+    }
+}

--- a/database/migrations/2024_01_01_000006_create_autobuilder_tags_tables.php
+++ b/database/migrations/2024_01_01_000006_create_autobuilder_tags_tables.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('autobuilder_tags', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->string('name')->unique();
+            $table->string('slug')->unique();
+            $table->timestamps();
+        });
+
+        Schema::create('autobuilder_flow_tag', function (Blueprint $table) {
+            $table->ulid('flow_id');
+            $table->ulid('tag_id');
+            $table->primary(['flow_id', 'tag_id']);
+            $table->foreign('flow_id')->references('id')->on('autobuilder_flows')->cascadeOnDelete();
+            $table->foreign('tag_id')->references('id')->on('autobuilder_tags')->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('autobuilder_flow_tag');
+        Schema::dropIfExists('autobuilder_tags');
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use Grazulex\AutoBuilder\Http\Controllers\BrickController;
 use Grazulex\AutoBuilder\Http\Controllers\ExecutionController;
 use Grazulex\AutoBuilder\Http\Controllers\FlowController;
 use Grazulex\AutoBuilder\Http\Controllers\HealthController;
+use Grazulex\AutoBuilder\Http\Controllers\TagController;
 use Grazulex\AutoBuilder\Http\Controllers\WebhookController;
 use Illuminate\Support\Facades\Route;
 
@@ -33,6 +34,12 @@ Route::prefix(config('autobuilder.routes.prefix', 'autobuilder'))
             Route::get('flows/{flow}/runs', [ExecutionController::class, 'runs'])->name('autobuilder.flows.runs');
             Route::get('runs/{run}', [ExecutionController::class, 'show'])->name('autobuilder.runs.show');
             Route::get('runs/{run}/logs', [ExecutionController::class, 'logs'])->name('autobuilder.runs.logs');
+
+            // Tags
+            Route::get('tags', [TagController::class, 'index'])->name('autobuilder.tags.index');
+            Route::post('tags', [TagController::class, 'store'])->name('autobuilder.tags.store');
+            Route::post('flows/{flow}/tags/{tag}', [TagController::class, 'attach'])->name('autobuilder.flows.tags.attach');
+            Route::delete('flows/{flow}/tags/{tag}', [TagController::class, 'detach'])->name('autobuilder.flows.tags.detach');
 
             // Bricks
             Route::get('bricks', [BrickController::class, 'index'])->name('autobuilder.bricks.index');

--- a/src/Http/Controllers/FlowController.php
+++ b/src/Http/Controllers/FlowController.php
@@ -27,6 +27,8 @@ class FlowController extends Controller
         $flows = Flow::query()
             ->when($request->has('active'), fn ($q) => $q->where('active', $request->boolean('active')))
             ->when($request->has('search'), fn ($q) => $q->where('name', 'like', '%'.$request->input('search').'%'))
+            ->when($request->has('tag'), fn ($q) => $q->withTag($request->input('tag')))
+            ->with('tags')
             ->withCount('runs')
             ->latest()
             ->paginate($request->input('per_page', 15));
@@ -52,7 +54,7 @@ class FlowController extends Controller
 
     public function show(Flow $flow): FlowResource
     {
-        $flow->loadCount('runs');
+        $flow->loadCount('runs')->load('tags');
 
         return new FlowResource($flow);
     }

--- a/src/Http/Controllers/TagController.php
+++ b/src/Http/Controllers/TagController.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Grazulex\AutoBuilder\Http\Controllers;
+
+use Grazulex\AutoBuilder\Models\Flow;
+use Grazulex\AutoBuilder\Models\Tag;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Str;
+
+class TagController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        $tags = Tag::orderBy('name')->get(['id', 'name', 'slug']);
+
+        return response()->json(['data' => $tags]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:50', 'unique:autobuilder_tags,name'],
+        ]);
+
+        $tag = Tag::create([
+            'name' => $validated['name'],
+            'slug' => Str::slug($validated['name']),
+        ]);
+
+        return response()->json(['data' => $tag], 201);
+    }
+
+    public function attach(string $flow, string $tag): JsonResponse
+    {
+        $flowModel = Flow::findOrFail($flow);
+        $tagModel = Tag::findOrFail($tag);
+
+        $flowModel->tags()->syncWithoutDetaching([$tagModel->id]);
+
+        return response()->json(['message' => 'Tag attached']);
+    }
+
+    public function detach(string $flow, string $tag): JsonResponse
+    {
+        $flowModel = Flow::findOrFail($flow);
+        $tagModel = Tag::findOrFail($tag);
+
+        $flowModel->tags()->detach($tagModel->id);
+
+        return response()->json(['message' => 'Tag detached']);
+    }
+}

--- a/src/Http/Resources/FlowResource.php
+++ b/src/Http/Resources/FlowResource.php
@@ -27,6 +27,11 @@ class FlowResource extends JsonResource
             'nodes_count' => count($this->nodes ?? []),
             'edges_count' => count($this->edges ?? []),
             'runs_count' => $this->whenCounted('runs'),
+            'tags' => $this->whenLoaded('tags', fn () => $this->tags->map(fn ($tag) => [
+                'id' => $tag->id,
+                'name' => $tag->name,
+                'slug' => $tag->slug,
+            ])),
             'created_by' => $this->created_by,
             'updated_by' => $this->updated_by,
             'created_at' => $this->created_at?->toIso8601String(),

--- a/src/Models/Flow.php
+++ b/src/Models/Flow.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
@@ -54,6 +55,11 @@ class Flow extends Model
     public function runs(): HasMany
     {
         return $this->hasMany(FlowRun::class);
+    }
+
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class, 'autobuilder_flow_tag');
     }
 
     public function createdBy(): BelongsTo
@@ -113,5 +119,10 @@ class Flow extends Model
     public function scopeActive($query)
     {
         return $query->where('active', true);
+    }
+
+    public function scopeWithTag($query, string $tag)
+    {
+        return $query->whereHas('tags', fn ($q) => $q->where('slug', $tag)->orWhere('name', $tag));
     }
 }

--- a/src/Models/Tag.php
+++ b/src/Models/Tag.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Grazulex\AutoBuilder\Models;
+
+use Grazulex\AutoBuilder\Database\Factories\TagFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Str;
+
+class Tag extends Model
+{
+    /** @use HasFactory<TagFactory> */
+    use HasFactory;
+
+    use HasUlids;
+
+    protected static function newFactory(): TagFactory
+    {
+        return TagFactory::new();
+    }
+
+    protected $table = 'autobuilder_tags';
+
+    protected $fillable = [
+        'name',
+        'slug',
+    ];
+
+    protected static function booted(): void
+    {
+        static::creating(function (Tag $tag): void {
+            if (empty($tag->slug)) {
+                $tag->slug = Str::slug($tag->name);
+            }
+        });
+    }
+
+    public function flows(): BelongsToMany
+    {
+        return $this->belongsToMany(Flow::class, 'autobuilder_flow_tag');
+    }
+}

--- a/tests/Feature/Http/TagControllerTest.php
+++ b/tests/Feature/Http/TagControllerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+use Grazulex\AutoBuilder\Models\Flow;
+use Grazulex\AutoBuilder\Models\Tag;
+
+beforeEach(function () {
+    $this->withoutMiddleware();
+});
+
+describe('index', function () {
+    it('returns all tags', function () {
+        Tag::factory()->count(3)->create();
+
+        $response = $this->getJson('/autobuilder/api/tags');
+
+        $response->assertOk();
+        $response->assertJsonStructure([
+            'data' => [
+                '*' => ['id', 'name', 'slug'],
+            ],
+        ]);
+        $response->assertJsonCount(3, 'data');
+    });
+});
+
+describe('store', function () {
+    it('creates a new tag', function () {
+        $response = $this->postJson('/autobuilder/api/tags', ['name' => 'Notifications']);
+
+        $response->assertStatus(201);
+        $response->assertJsonPath('data.name', 'Notifications');
+        $response->assertJsonPath('data.slug', 'notifications');
+
+        expect(Tag::where('name', 'Notifications')->exists())->toBeTrue();
+    });
+
+    it('rejects duplicate tag names', function () {
+        Tag::factory()->create(['name' => 'Existing', 'slug' => 'existing']);
+
+        $response = $this->postJson('/autobuilder/api/tags', ['name' => 'Existing']);
+
+        $response->assertUnprocessable();
+    });
+
+    it('requires a name', function () {
+        $response = $this->postJson('/autobuilder/api/tags', []);
+
+        $response->assertUnprocessable();
+    });
+});
+
+describe('attach', function () {
+    it('attaches a tag to a flow', function () {
+        $flow = Flow::factory()->create();
+        $tag = Tag::factory()->create();
+
+        $response = $this->postJson("/autobuilder/api/flows/{$flow->id}/tags/{$tag->id}");
+
+        $response->assertOk();
+        expect($flow->tags()->where('tag_id', $tag->id)->exists())->toBeTrue();
+    });
+
+    it('is idempotent (no duplicate pivot rows)', function () {
+        $flow = Flow::factory()->create();
+        $tag = Tag::factory()->create();
+
+        $this->postJson("/autobuilder/api/flows/{$flow->id}/tags/{$tag->id}");
+        $this->postJson("/autobuilder/api/flows/{$flow->id}/tags/{$tag->id}");
+
+        expect($flow->tags()->count())->toBe(1);
+    });
+});
+
+describe('detach', function () {
+    it('detaches a tag from a flow', function () {
+        $flow = Flow::factory()->create();
+        $tag = Tag::factory()->create();
+        $flow->tags()->attach($tag->id);
+
+        $response = $this->deleteJson("/autobuilder/api/flows/{$flow->id}/tags/{$tag->id}");
+
+        $response->assertOk();
+        expect($flow->tags()->count())->toBe(0);
+    });
+});
+
+describe('filter by tag', function () {
+    it('filters flows by tag in index', function () {
+        $tag = Tag::factory()->create(['name' => 'critical', 'slug' => 'critical']);
+        $taggedFlow = Flow::factory()->create(['name' => 'Tagged Flow']);
+        Flow::factory()->create(['name' => 'Other Flow']);
+
+        $taggedFlow->tags()->attach($tag->id);
+
+        $response = $this->getJson('/autobuilder/api/flows?tag=critical');
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.name', 'Tagged Flow');
+    });
+});

--- a/tests/Feature/TagTest.php
+++ b/tests/Feature/TagTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+use Grazulex\AutoBuilder\Models\Flow;
+use Grazulex\AutoBuilder\Models\Tag;
+
+it('can create a tag with auto slug', function () {
+    $tag = Tag::create(['name' => 'My Tag']);
+
+    expect($tag->id)->not->toBeEmpty();
+    expect($tag->name)->toBe('My Tag');
+    expect($tag->slug)->toBe('my-tag');
+});
+
+it('can attach a tag to a flow', function () {
+    $flow = Flow::factory()->create();
+    $tag = Tag::factory()->create();
+
+    $flow->tags()->attach($tag->id);
+
+    expect($flow->tags()->count())->toBe(1);
+    expect($flow->tags()->first()->id)->toBe($tag->id);
+});
+
+it('can detach a tag from a flow', function () {
+    $flow = Flow::factory()->create();
+    $tag = Tag::factory()->create();
+
+    $flow->tags()->attach($tag->id);
+    $flow->tags()->detach($tag->id);
+
+    expect($flow->tags()->count())->toBe(0);
+});
+
+it('can filter flows by tag slug', function () {
+    $tag = Tag::factory()->create(['name' => 'critical', 'slug' => 'critical']);
+    $taggedFlow = Flow::factory()->create();
+    $untaggedFlow = Flow::factory()->create();
+
+    $taggedFlow->tags()->attach($tag->id);
+
+    $results = Flow::withTag('critical')->get();
+
+    expect($results)->toHaveCount(1);
+    expect($results->first()->id)->toBe($taggedFlow->id);
+});
+
+it('can filter flows by tag name', function () {
+    $tag = Tag::factory()->create(['name' => 'onboarding', 'slug' => 'onboarding']);
+    $taggedFlow = Flow::factory()->create();
+
+    $taggedFlow->tags()->attach($tag->id);
+
+    $results = Flow::withTag('onboarding')->get();
+
+    expect($results)->toHaveCount(1);
+});
+
+it('a flow can have multiple tags', function () {
+    $flow = Flow::factory()->create();
+    $tags = Tag::factory()->count(3)->create();
+
+    $flow->tags()->attach($tags->pluck('id'));
+
+    expect($flow->tags()->count())->toBe(3);
+});
+
+it('deleting a tag removes pivot entries', function () {
+    $flow = Flow::factory()->create();
+    $tag = Tag::factory()->create();
+
+    $flow->tags()->attach($tag->id);
+    $tag->delete();
+
+    expect($flow->fresh()->tags()->count())->toBe(0);
+});
+
+it('tag slugs are unique', function () {
+    Tag::create(['name' => 'Notifications']);
+
+    expect(fn () => Tag::create(['name' => 'Notifications']))->toThrow(\Illuminate\Database\QueryException::class);
+});


### PR DESCRIPTION
## Summary

- Add reusable tag system for flows (many-to-many relationship)
- Tags are global, shared across all flows, with auto-generated slugs
- Flows can have multiple tags; a flow can belong to one folder but many tags
- Cascading delete on pivot when a tag is removed

## New API Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| `GET` | `/autobuilder/api/tags` | List all available tags |
| `POST` | `/autobuilder/api/tags` | Create a new tag |
| `POST` | `/autobuilder/api/flows/{flow}/tags/{tag}` | Attach tag to flow (idempotent) |
| `DELETE` | `/autobuilder/api/flows/{flow}/tags/{tag}` | Detach tag from flow |

## Flow Index Filter

```
GET /autobuilder/api/flows?tag=critical
```

Tags are included in `FlowResource` response when loaded.

## Test plan

- [x] 885 tests pass (16 new tests added)
- [x] Pint style check passes
- [x] Tag model: auto-slug, unique constraint, cascading pivot delete
- [x] HTTP: index, create, attach (idempotent), detach, filter by tag

Closes #29